### PR TITLE
Remove duplicate vprintf and copy args for file

### DIFF
--- a/PMAP-unix/platform-unix.c
+++ b/PMAP-unix/platform-unix.c
@@ -241,21 +241,22 @@ void PlatShowMessageB(const char *format, ...)
         return; // Exit early if format is NULL
     }
 
-    va_list args;
+    va_list args, args_copy;
 
     // Print to standard output
     va_start(args, format);
-    vprintf(format, args);
+    va_copy(args_copy, args);
+
     vprintf(format, args);
     va_end(args); // Clean up after using args for vprintf
 
     // Print to debug output file, if specified
     if (DebugOutputFile != NULL)
     {
-        va_start(args, format); // Reinitialize args for vfprintf
-        vfprintf(DebugOutputFile, format, args);
-        va_end(args); // Clean up after using args for vfprintf
+        vfprintf(DebugOutputFile, format, args_copy);
     }
+
+    va_end(args_copy);
 
     // Block until the user presses ENTER
     while (getchar() != '\n')


### PR DESCRIPTION
## Pull Request checklist

Note: these are not necessarily requirements

- [x] I reformatted the code with clang-format
- [ ] I checked to make sure my submission worked
- [x] I am the author of submission or have permission from the original author
- [ ] Requires update of the PS2SDK or other dependencies
- [ ] Others (please specify below)

## Pull Request description
Noticed that vprintf was called twice back to back. Ive removed the duplicate call and slightly refactored to copy the args before printing to a debug file to be paranoid that the args are not mutated from that point so that the output is consistent.